### PR TITLE
Add dbconfig.xml options to stop health warnings

### DIFF
--- a/imagescripts/launch.sh
+++ b/imagescripts/launch.sh
@@ -40,6 +40,11 @@ if [ -n "$JIRA_DATABASE_URL" ]; then
     <pool-max-idle>20</pool-max-idle>
     <pool-remove-abandoned>true</pool-remove-abandoned>
     <pool-remove-abandoned-timeout>300</pool-remove-abandoned-timeout>
+    <validation-query>select version();</validation-query>
+    <min-evictable-idle-time-millis>60000</min-evictable-idle-time-millis>
+    <time-between-eviction-runs-millis>300000</time-between-eviction-runs-millis>
+    <pool-test-on-borrow>false</pool-test-on-borrow>
+    <pool-test-while-idle>true</pool-test-while-idle>
   </jdbc-datasource>
 </jira-database-config>
 END


### PR DESCRIPTION
As of version 7.1.4, JIRA will show a warning about the database not being configured as recommended. The health check states that the database config is missing settings for `validation-query`, `pool-test-on-borrow` and `pool-test-while-idle`:

<img width="953" alt="screenshot" src="https://cloud.githubusercontent.com/assets/426606/19494188/3d8da142-957e-11e6-83f5-70476bc3965e.png">

For further explanation see the official docs: [How can I resolve this?](https://confluence.atlassian.com/jirakb/health-check-database-connection-settings-792636748.html#HealthCheck:DatabaseConnectionSettings-Resolution)

This patch is based on code from that page and should eliminate the warnings.
